### PR TITLE
Enable configuration of version to bypass autodetection

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This action will read a `package.json` file and compare the `version` attribute 
 
 ## Usage
 
-The following is an example `.github/main.workflow` that will execute when a `push` to the `master` branch occurs. 
+The following is an example `.github/main.workflow` that will execute when a `push` to the `master` branch occurs.
 
 ```yaml
 name: My Workflow
 
-on: 
+on:
   push:
     branches:
     - master
@@ -52,48 +52,60 @@ The action will automatically extract the token at runtime. **DO NOT MANUALLY EN
 There are several options to customize how the tag is created.
 
 1. `package_root`
-    
+
     By default, autotag will look for the `package.json` file in the project root. If the file is located in a subdirectory, this option can be used to point to the correct file.
-    
+
     ```yaml
     - uses: butlerlogic/action-autotag@1.0.0
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         package_root: "/path/to/subdirectory"
     ```
-    
+
 1. `tag_prefx`
-    
+
     By default, `package.json` uses [semantic versioning](https://semver.org/), such as `1.0.0`. A prefix can be used to add text before the tag name. For example, if `tag_prefx` is set to `v`, then the tag would be labeled as `v1.0.0`.
-    
+
     ```yaml
     - uses: butlerlogic/action-autotag@1.0.0
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         tag_prefx: "v"
     ```
-    
+
 1. `tag_suffix`
-    
+
     Text can also be applied to the end of the tag by setting `tag_suffix`. For example, if `tag_suffix` is ` (beta)`, the tag would be `1.0.0 (beta)`. Please note this example violates semantic versioning and is merely here to illustrate how to add text to the end of a tag name if you _really_ want to.
-    
+
     ```yaml
     - uses: butlerlogic/action-autotag@1.0.0
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         tag_suffix: " (beta)"
     ```
-    
+
 1. `tag_message`
-    
+
     This is the annotated commit message associated with the tag. By default, a
     changelog will be generated from the commits between the latest tag and the new tag (HEAD). Setting this option will override it witha custom message.
-    
+
     ```yaml
     - uses: butlerlogic/action-autotag@1.0.0
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         tag_message: "Custom message goes here."
+    ```
+
+1. `version`
+
+    Explicitly set the version instead of automatically detecting from `package.json`.
+    Useful for non-JavaScript projects where version may be output by a previous action.
+
+    ```yaml
+    - uses: butlerlogic/action-autotag@1.0.0
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        version: "${{ steps.previous_step.outputs.version }}"
     ```
 
 ## Developer Notes

--- a/action.yml
+++ b/action.yml
@@ -1,14 +1,14 @@
-name: 'Autotagger'
-description: 'Automatically generate new tags when the package.json version changes.'
-author: 'ButlerLogic'
+name: "Autotagger"
+description: "Automatically generate new tags when the package.json version changes."
+author: "ButlerLogic"
 branding:
-  icon: 'tag'  
-  color: 'black'
+  icon: "tag"
+  color: "black"
 inputs:
   package_root:
     description: Autotag will look for the package.json file in in this location.
     required: false
-    default: './'
+    default: "./"
   tag_prefx:
     description: By default, package.json uses semantic versioning, such as "1.0.0". A prefix can be used to add text before the tag name. For example, if tag_prefx is set to "v", then the tag would be labeled as "v1.0.0".
     required: false
@@ -17,6 +17,9 @@ inputs:
     required: false
   tag_message:
     description: This is the annotated commit message associated with the tag. By default, a changelog will be generated from the commits between the latest tag and the new tag (HEAD). This will override that with a hard-coded message.
+    required: false
+  version:
+    description: Explicitly set the version here instead of automatically detecting from `package.json`. Useful for non-JavaScript projects where version may be output by a previous action.
     required: false
 outputs:
   tagname:
@@ -28,7 +31,7 @@ outputs:
   tagmessage:
     description: The messge applied to the tag reference (this is what shows up on the tag screen on Github).
   version:
-    description: The version, as defined in package.json.
+    description: The version, as defined in package.json or explicitly set in the input.
 runs:
-  using: 'node12'
-  main: 'lib/main.js'
+  using: "node12"
+  main: "lib/main.js"

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,24 +8,31 @@ async function run() {
   try {
     core.debug(` Available environment variables:\n -> ${Object.keys(process.env).map(i => i + ' :: ' + process.env[i]).join('\n -> ')}`)
 
-    let dir = fs.readdirSync(path.resolve(process.env.GITHUB_WORKSPACE), { withFileTypes: true }).map(entry => {
-      return `${entry.isDirectory() ? '> ' : '  - '}${entry.name}`
-    }).join('\n')
+    let version = ""
 
-    core.debug(` Working Directory: ${process.env.GITHUB_WORKSPACE}:\n${dir}`)
-    
-    const pkg_root = core.getInput('package_root', { required: false })
-    let pkgfile = path.join(process.env.GITHUB_WORKSPACE, pkg_root, 'package.json')
+    if (!process.env.hasOwnProperty('INPUT_VERSION') || process.env.INPUT_VERSION.trim().length === 0) {
+      let dir = fs.readdirSync(path.resolve(process.env.GITHUB_WORKSPACE), { withFileTypes: true }).map(entry => {
+        return `${entry.isDirectory() ? '> ' : '  - '}${entry.name}`
+      }).join('\n')
 
-    if (!fs.existsSync(pkgfile)) {
-      core.setFailed('package.json does not exist.')
-      return
+      core.debug(` Working Directory: ${process.env.GITHUB_WORKSPACE}:\n${dir}`)
+
+      const pkg_root = core.getInput('package_root', { required: false })
+      let pkgfile = path.join(process.env.GITHUB_WORKSPACE, pkg_root, 'package.json')
+
+      if (!fs.existsSync(pkgfile)) {
+        core.setFailed('package.json does not exist.')
+        return
+      }
+
+      let pkg = require(pkgfile)
+      version = pkg.version
+    } else {
+      version = process.env.INPUT_VERSION.trim()
     }
 
-    let pkg = require(pkgfile)
-
-    core.setOutput('version', pkg.version)
-    core.debug(` Detected version ${pkg.version}`)
+    core.setOutput('version', version)
+    core.debug(` Detected version ${version}`)
 
     if (!process.env.hasOwnProperty('INPUT_GITHUB_TOKEN') || process.env.INPUT_GITHUB_TOKEN.trim().length === 0) {
       core.setFailed('Invalid or missing GITHUB_TOKEN.')
@@ -52,7 +59,7 @@ async function run() {
 
     // Check for existance of tag and abort (short circuit) if it already exists.
     for (let tag of tags.data) {
-      if (tag.name.trim().toLowerCase() === pkg.version.trim().toLowerCase()) {
+      if (tag.name.trim().toLowerCase() === version.trim().toLowerCase()) {
         core.warning(`"${tag.name.trim()}" tag already exists.`)
         core.setOutput('tagname', '')
         return
@@ -60,7 +67,7 @@ async function run() {
     }
 
     // Create the new tag name
-    let tagName = pkg.version
+    let tagName = version
     const tagPrefix = core.getInput('tag_prefix', { required: false })
     const tagSuffix = core.getInput('tag_suffix', { required: false })
     let tagMsg = core.getInput('tag_message', { required: false }).trim()
@@ -90,7 +97,7 @@ async function run() {
     try {
       tagMsg = tagMsg.trim().length > 0
         ? tagMsg
-        : `Version ${pkg.version}`
+        : `Version ${version}`
 
       newTag = await git.git.createTag({
         owner,


### PR DESCRIPTION
Closes #8.

This PR enables users to specify the version as an input (probably using the output of a previous step) which bypasses the autodetection from `package.json`.

The result of this is that the action will now be useful in more than just NodeJS projects.

_Looks like my editor got a little excited and stipped whitespace and fixed quotes in a bunch of places. Happy to revert is required._