### PR TITLE
Add dry_run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,19 @@ Useful for projects where the version number may be output by a previous action.
     version: "${{ steps.previous_step.outputs.version }}"
 ```
 
+### dry_run
+
+If this value is true, the tag will not be pushed.
+You can check for duplicate versions when creating a pull request.
+
+```yaml
+- uses: butlerlogic/action-autotag@1.0.0
+  with:
+    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    dry_run: true
+```
+
+
 ## Developer Notes
 
 If you are building an action that runs after this one, be aware this action produces several [outputs](https://help.github.com/en/articles/metadata-syntax-for-github-actions#outputs):

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,9 @@ inputs:
   regex_pattern:
     description: An optional attribute containing the regular expression used to extract the version number.
     required: false
+  dry_run:
+    description: If this value is true, the tag will not be pushed.
+    required: false
 outputs:
   tagname:
     description: Returns the new tag value. Empty if a tag is not created.

--- a/app/main.js
+++ b/app/main.js
@@ -17,7 +17,9 @@ async function run () {
     // Identify the tag parsing strategy
     const root = core.getInput('root', { required: false }) || core.getInput('package_root', { required: false }) || './'
     const strategy = (core.getInput('regex_pattern', { required: false }) || '').trim().length > 0 ? 'regex' : ((core.getInput('strategy', { required: false }) || 'package').trim().toLowerCase())
-    
+
+    // If this value is true, the tag will not be pushed
+    const isDryRun = core.getInput('dry_run', { required: false });
 
     // Extract the version number using the supplied strategy
     let version = core.getInput('root', { required: false })
@@ -60,22 +62,29 @@ async function run () {
       core.getInput('tag_suffix', { required: false })
     )
 
-    core.warning(`Attempting to create ${tag.name} tag.`)
+    if (isDryRun === "true") {
+      core.warning(`"${tag.name}" tag is not pushed because the dry_run option was set.`)
+    } else {
+      core.warning(`Attempting to create ${tag.name} tag.`)
+    }
+
     core.setOutput('tagrequested', tag.name)
     core.setOutput('prerelease', tag.prerelease ? 'yes' : 'no')
     core.setOutput('build', tag.build ? 'yes' : 'no')
 
     // Check for existance of tag and abort (short circuit) if it already exists.
     if (await tag.exists()) {
-      core.warning(`"${tag.name}" tag already exists.` + os.EOL)
+      core.setFailed(`"${tag.name}" tag already exists.` + os.EOL)
       core.setOutput('tagname', '')
       return
     }
 
     // The tag setter will autocorrect the message if necessary.
     tag.message = core.getInput('tag_message', { required: false }).trim()
-    await tag.push()
 
+    if (isDryRun !== "true") {
+      await tag.push()
+    }
     core.setOutput('tagname', tag.name)
     core.setOutput('tagsha', tag.sha)
     core.setOutput('taguri', tag.uri)


### PR DESCRIPTION
I would like to propose dry_run option. If this value is true, the tag will not be pushed.

This option can be used with on:pull_request to prevent forgetting to raise the version in package.json.
If the version tag in package.json exists, the action will fail.
