### PR TITLE
[Bugfix] GIT tag message was not populated

### DIFF
--- a/app/lib/tag.js
+++ b/app/lib/tag.js
@@ -30,6 +30,10 @@ export default class Tag {
     }
   }
 
+  get message() {
+    return this._message || ''
+  }
+
   get sha () {
     return this._sha || ''
   }
@@ -63,6 +67,7 @@ export default class Tag {
       }
 
       const changelog = await github.repos.compareCommits({ owner, repo, base: tags.shift().name, head: 'master' })
+
       const tpl = (core.getInput('commit_message_template', { required: false }) || '').trim()
 
       return changelog.data.commits
@@ -125,11 +130,12 @@ export default class Tag {
 
     if (!tagexists) {
       // Create tag
+      const message = await this.getMessage()
       const newTag = await github.git.createTag({
         owner,
         repo,
         tag: this.name,
-        message: await this.getMessage(),
+        message,
         object: process.env.GITHUB_SHA,
         type: 'commit'
       })
@@ -160,6 +166,7 @@ export default class Tag {
 
       this._uri = newReference.data.url
       this._ref = newReference.data.ref
+      this._message = message;
 
       core.warning(`Reference ${newReference.data.ref} available at ${newReference.data.url}` + os.EOL)
     } else {

--- a/app/main.js
+++ b/app/main.js
@@ -72,8 +72,8 @@ async function run () {
       return
     }
 
-    // // The tag setter will autocorrect the message if necessary.
-    // tag.message = core.getInput('tag_message', { required: false }).trim()
+    // The tag setter will autocorrect the message if necessary.
+    tag.message = core.getInput('tag_message', { required: false }).trim()
     await tag.push()
 
     core.setOutput('tagname', tag.name)

--- a/app/main.js
+++ b/app/main.js
@@ -72,8 +72,8 @@ async function run () {
       return
     }
 
-    // The tag setter will autocorrect the message if necessary.
-    tag.message = core.getInput('tag_message', { required: false }).trim()
+    // // The tag setter will autocorrect the message if necessary.
+    // tag.message = core.getInput('tag_message', { required: false }).trim()
     await tag.push()
 
     core.setOutput('tagname', tag.name)


### PR DESCRIPTION
# Description
We had an issue that the actual `tagmessage` property was never populated in the output properties. I took a look at it and found out that the property is actually never set except when it is set outside as an input to the action. 

We came up with the solution to add the message to the tag properties. This fixed our build and is now working as intended.