### PR TITLE
Support of "composer" strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This action will auto-generate a Github tag whenever a new version is detected. The following "detection strategies" are available:
 
 1. **package**: Monitor a `package.json` for new versions.
+1. **composer**: Monitor a `composer.json` for new versions.
 1. **docker**: Monitor a `Dockerfile` for a `LABEL version=x.x.x` value.
 1. **regex**: Use a JavaScript [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) with any file for your own custom extraction.
 
@@ -69,6 +70,7 @@ There are several options to customize how the tag is created.
 This is the strategy used to identify the version number/tag from within the code base.
 
 1. _package_: Monitor a `package.json` for new versions. Use this for JavaScript projects based on Node modules (npm, yarn, etc).
+1. _composer_: Monitor a `composer.json` for new versions. Use this for PHP projects based on Composer packages.
 1. _docker_: Monitor a `Dockerfile` for a `LABEL version=x.x.x` value. USe this for container projects.
 1. _regex*_: Use a JavaScript [regular expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp) with any file for your own custom extraction.
 
@@ -84,7 +86,7 @@ This is the strategy used to identify the version number/tag from within the cod
 ### root
 _Formerly `package_root`_
 
-Depending on the selected strategy, autotagger will look for the `package.json` or `Dockerfile` file in the project root. If the file is located in a subdirectory, this option can be used to point to the correct file.
+Depending on the selected strategy, autotagger will look for the `package.json`, `composer.json` or `Dockerfile` file in the project root. If the file is located in a subdirectory, this option can be used to point to the correct file.
 
 _Using the **package** strategy:_
 
@@ -97,6 +99,18 @@ _Using the **package** strategy:_
 ```
 
 The version number would be extracted from `/path/to/subdirectory/package.json`.
+
+_Using the **composer** strategy:_
+
+```yaml
+- uses: butlerlogic/action-autotag@1.0.0
+  with:
+    GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    strategy: composer
+    root: "/path/to/subdirectory"
+```
+
+The version number would be extracted from `/path/to/subdirectory/composer.json`.
 
 _Using the **docker** strategy:_
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: './'
   strategy:
-    description: Options include 'package' (for package.json), 'docker' (for Dockerfile), and 'regex' to extract from an arbitrary file. This does not need to be specified if the "regex_pattern" property is provided.
+    description: Options include 'package' (for package.json), 'docker' (for Dockerfile), 'composer' (for composer.json) and 'regex' to extract from an arbitrary file. This does not need to be specified if the "regex_pattern" property is provided.
     required: false
     default: 'package'
   package_root:

--- a/app/lib/composer.js
+++ b/app/lib/composer.js
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+
+export default class Composer {
+  constructor (root = './') {
+    root = path.join(process.env.GITHUB_WORKSPACE, root)
+
+    if (fs.statSync(root).isDirectory()) {
+      root = path.join(root, 'composer.json')
+    }
+
+    if (!fs.existsSync(root)) {
+      throw new Error(`package.json does not exist at ${root}.`)
+    }
+
+    this.root = root
+    this.data = JSON.parse(fs.readFileSync(root))
+  }
+
+  get version () {
+    return this.data.version
+  }
+}

--- a/app/main.js
+++ b/app/main.js
@@ -5,6 +5,7 @@ import Package from './lib/package.js'
 import Tag from './lib/tag.js'
 import Regex from './lib/regex.js'
 import Dockerfile from './lib/docker.js'
+import Composer from "./lib/composer.js";
 
 async function run () {
   try {
@@ -34,12 +35,16 @@ async function run () {
         version = (new Package(root)).version
         break
 
+      case 'composer':
+        version = (new Composer(root)).version
+        break
+
       case 'regex':
         version = (new Regex(root, new RegExp(pattern, 'gim'))).version
         break
 
       default:
-        core.setFailed(`"${strategy}" is not a recognized tagging strategy. Choose from: 'package' (package.json), 'docker' (uses Dockerfile), or 'regex' (JS-based RegExp).`)
+        core.setFailed(`"${strategy}" is not a recognized tagging strategy. Choose from: 'package' (package.json), 'composer' (uses composer.json), 'docker' (uses Dockerfile), or 'regex' (JS-based RegExp).`)
         return
     }
 


### PR DESCRIPTION
Hey there!

Proposing to add a "composer" strategy for PHP projects.
I pretty understand that this could be covered with "regex" strategy, but it would be great to have a support of it "out of the box" 😊. 

*Implementation (copy-paste actually 🙈) was easy as the structure of `package.json` and `composer.json` similar!

Would be great to here your opinion!