### PR TITLE
Fix: don't fail if the tag already exists

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -105,7 +105,7 @@ async function run () {
 
     // Check for existance of tag and abort (short circuit) if it already exists.
     if (await tag.exists()) {
-      core.setFailed(`"${tag.name}" tag already exists.` + os.EOL)
+      core.warning(`"${tag.name}" tag already exists.` + os.EOL)
       core.setOutput('tagname', '')
       return
     }


### PR DESCRIPTION
Previously, if the tag to create was deemed to already exist, a warning would be logged and the action would not attempt to create it.

However, a recently merged commit [0] changed this behaviour, by marking the action as failed if the tag already exists, instead of simply emitting a warning.

Therefore, to prevent the action from failing when the tag already exists, revert to the previous behaviour and emit a warning instead.

[0] https://github.com/ButlerLogic/action-autotag/commit/8a4f4d8b4fa0aefbbedf904bcb6fc96defb8bf3d

Signed-off-by: Antoine Busque <antoinebusque@gmail.com>