### PR TITLE
Change uses to env in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The `GITHUB_TOKEN` **must** be provided. Without this, it is not possible to cre
 
 ```yaml
 - uses: butlerlogic/action-autotag@stable
-  with:
+  env:
     GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 ```
 


### PR DESCRIPTION
The package takes the GitHub token under `env` rather than `with`. This updates the example to do this